### PR TITLE
Use xcrun for CC and CXX in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ XCODEROOT = $(shell xcode-select -print-path)
 
 CC = xcrun clang
 CXX = xcrun clang++
-IBTOOL = $(XCODEROOT)/usr/bin/ibtool
+IBTOOL = xcrun ibtool
 
 REPO_VERSION := $(shell git log --oneline | wc -l | sed 's/ //g')
 SHORT_VERSION = r$(REPO_VERSION)


### PR DESCRIPTION
This switches CC and CXX to use "xcrun clang" and "xcrun clang++" to deal with
the fact that newer XCodes don't install system tools in root paths by default.
The above commands will correctly look in the path set by xcode-select for the
appropriate tools.
