### PR TITLE
Maintain visual mode when shifting left/right

### DIFF
--- a/app/ViTextView-vi_commands.m
+++ b/app/ViTextView-vi_commands.m
@@ -2200,10 +2200,9 @@
 	final_location = start_location;
 	[self changeIndentation:(mode == ViVisualMode ? IMAX(1, command.count) : 1)
 			inRange:affectedRange
-		    updateCaret:NULL
+		    updateCaret:&final_location
 		 alignToTabstop:NO
 	       indentEmptyLines:NO];
-	final_location = [[self textStorage] firstNonBlankForLineAtLocation:affectedRange.location];
 	return YES;
 }
 
@@ -2216,10 +2215,9 @@
 	final_location = start_location;
 	[self changeIndentation:(mode == ViVisualMode ? IMIN(-1, -command.count) : -1)
 			inRange:affectedRange
-		    updateCaret:NULL
+		    updateCaret:&final_location
 		 alignToTabstop:NO
 	       indentEmptyLines:NO];
-	final_location = [[self textStorage] firstNonBlankForLineAtLocation:affectedRange.location];
 	return YES;
 }
 

--- a/app/ViTextView.m
+++ b/app/ViTextView.m
@@ -2214,6 +2214,8 @@ replaceCharactersInRange:(NSRange)aRange
 
 	BOOL leaveVisualMode = NO;
 	if (mode == ViVisualMode && !command.isMotion &&
+	    command.action != @selector(shift_right:) &&
+	    command.action != @selector(shift_left:) &&
 	    command.action != @selector(visual:) &&
 	    command.action != @selector(visual_other:) &&
 	    command.action != @selector(visual_line:)) {


### PR DESCRIPTION
Updated the shift_left: (<) and shift_right: (>) commands to remain in visual mode after shifting, as in vim
