### PR TITLE
Implement splitright option

### DIFF
--- a/app/ViAppController.m
+++ b/app/ViAppController.m
@@ -304,6 +304,7 @@ updateMeta(void)
 	    [NSNumber numberWithInt:80], @"guidecolumn",
 	    [NSNumber numberWithFloat:12.0], @"fontsize",
 	    [NSNumber numberWithFloat:0.75], @"blinktime",
+	    [NSNumber numberWithBool:NO], @"splitright",
 	    @"none", @"blinkmode",
 	    @"Monaco", @"fontname",
 	    @"vim", @"undostyle",

--- a/app/ViTabController.m
+++ b/app/ViTabController.m
@@ -194,6 +194,11 @@
 	DEBUG(@"adding view %@ = %@", [newViewController view], newViewController);
 	DEBUG(@"subviews = %@", [split subviews]);
 
+    BOOL splitright = [[NSUserDefaults standardUserDefaults] boolForKey:@"splitright"];
+    if(splitright == NSOnState){
+      position = ViViewPositionSplitRight;
+    }
+
 	BOOL isVertical = (position == ViViewPositionSplitLeft || position == ViViewPositionSplitRight);
 	NSWindowOrderingMode mode;
 	if (isVertical)

--- a/app/ViWindowController.m
+++ b/app/ViWindowController.m
@@ -2613,13 +2613,14 @@ additionalEffectiveRectOfDividerAtIndex:(NSInteger)dividerIndex
 		@"linebreak", @"lbr",
 		@"blinktime", @"blinktime",
 		@"blinkmode", @"blinkmode",
+        @"splitright", @"spr",
 		nil];
 
 	NSArray *booleans = [NSArray arrayWithObjects:
 	    @"autoindent", @"expandtab", @"smartpair", @"ignorecase", @"smartcase", @"number",
 	    @"autocollapse", @"hidetab", @"showguide", @"searchincr", @"smartindent",
 	    @"wrap", @"antialias", @"list", @"smarttab", @"prefertabs", @"cursorline", @"gdefault",
-	    @"wrapscan", @"clipboard", @"matchparen", @"flashparen", @"linebreak",
+	    @"wrapscan", @"clipboard", @"matchparen", @"flashparen", @"linebreak", @"splitright",
 	    nil];
 
 	NSString *var;


### PR DESCRIPTION
In Vim I can `:set splitright` or `:set spr` to make Vim open splits on the right. Vico already has the functionality to do this, but didn't expose the option. This commit makes it available.

Is there anything else I'd need to do for this or is this good enough?
