### PR TITLE
Allow filterless :! commands

### DIFF
--- a/app/ViTextView-ex_commands.m
+++ b/app/ViTextView-ex_commands.m
@@ -191,13 +191,8 @@
 - (id)ex_bang:(ExCommand *)command
 {
 	if (command.naddr == 0) {
-		ExMapping *shell = [[ExMap defaultMap] lookup:@"shell"];
-		if (shell == nil) {
-			return [ViError message:@"Non-filtering version of ! not implemented"];
-		}
-		ExCommand *shellCommand = [ExCommand commandWithMapping:shell];
-		shellCommand.arg = command.arg;
-		[self evalExCommand:shellCommand];
+		id target = [[self superview] targetForSelector:@selector(ex_bang:)];
+		return [target ex_bang:command];
 	}
 	if ([self filterRange:command.range throughCommand:command.arg])
 		command.caret = command.range.location;

--- a/app/ViTextView-ex_commands.m
+++ b/app/ViTextView-ex_commands.m
@@ -27,6 +27,8 @@
 #import "ViAppController.h"
 #import "ViEventManager.h"
 #import "ViError.h"
+#import "ViBundleCommand.h"
+#import "ViTaskRunner.h"
 #import "NSString-additions.h"
 #import "ViRegisterManager.h"
 #import "NSView-additions.h"
@@ -191,8 +193,43 @@
 - (id)ex_bang:(ExCommand *)command
 {
 	if (command.naddr == 0) {
-		id target = [[self superview] targetForSelector:@selector(ex_bang:)];
-		return [target ex_bang:command];
+		ViTaskRunner *runner = [[ViTaskRunner alloc] init];
+		NSError *error = nil;
+		NSString *cwd = nil;
+		NSURL *baseURL = [[document fileURL] URLByDeletingLastPathComponent];
+		if ([baseURL isFileURL])
+			cwd = [baseURL path];
+		NSMutableDictionary *env = [NSMutableDictionary dictionary];
+		NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:
+			[[ViBundleCommand alloc]
+				initFromDictionary:
+							 [NSDictionary dictionaryWithObjectsAndKeys:
+									command.arg, @"name",
+									command.arg, @"command",
+									@"showashtml", @"output",
+									@"ex_bang command", @"uuid", nil]
+					      inBundle:nil], @"command",
+			[NSValue valueWithRange:NSMakeRange(NSNotFound, 0)], @"inputRange",
+			[NSValue valueWithRange:NSMakeRange(NSNotFound, 0)], @"selectedRange",
+			nil];
+		[ViBundle setupEnvironment:env
+				   forTextView:self
+				inputRange:NSMakeRange(NSNotFound, 0)
+					window:[self window]
+					bundle:nil];
+		[runner launchShellCommand:command.arg
+				 withStandardInput:[[NSData alloc] init]
+					   environment:env
+				  currentDirectory:cwd
+			asynchronouslyInWindow:[self window]
+							 title:command.arg
+							target:self
+						  selector:@selector(bundleCommand:finishedWithStatus:contextInfo:)
+					   contextInfo:info
+							 error:&error];
+
+		if (error)
+			MESSAGE(@"%@", [error localizedDescription]);
 	}
 	if ([self filterRange:command.range throughCommand:command.arg])
 		command.caret = command.range.location;

--- a/app/ViTextView-vi_commands.m
+++ b/app/ViTextView-vi_commands.m
@@ -523,8 +523,12 @@
 
 	NSString *inputText = [[[self textStorage] string] substringWithRange:range];
 
+	NSString *shell = [[[NSProcessInfo processInfo] environment] objectForKey:@"SHELL"];
+	if (! [[NSFileManager defaultManager] isExecutableFileAtPath:shell])
+		shell = @"/bin/bash";
+
 	NSTask *task = [[[NSTask alloc] init] autorelease];
-	[task setLaunchPath:@"/bin/bash"];
+	[task setLaunchPath:shell];
 	[task setArguments:[NSArray arrayWithObjects:@"-c", shellCommand, nil]];
 
 	NSMutableDictionary *env = [NSMutableDictionary dictionary];
@@ -3195,6 +3199,8 @@ again:
 
 	// FIXME: replace completion command keys (<c-n> or <c-x><c-n>) with the completed text
 	// [self removeFromInputKeys:command];
+
+	NSLog(@"Doin' it right...");
 
 	return [self presentCompletionsOf:word
 			     fromProvider:[[[ViWordCompletion alloc] init] autorelease]

--- a/app/ViWindowController.m
+++ b/app/ViWindowController.m
@@ -2650,17 +2650,6 @@ additionalEffectiveRectOfDividerAtIndex:(NSInteger)dividerIndex
 	return nil;
 }
 
-- (id)ex_bang:(ExCommand *)command
-{
-	// We only deal with zero-argument :! commands here.
-	if (command.naddr > 0)
-		return nil;
-
-	NSLog(@"And here we are...");
-
-	return nil;
-}
-
 - (id)ex_set:(ExCommand *)command
 {
 	NSDictionary *variables = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/app/ViWindowController.m
+++ b/app/ViWindowController.m
@@ -2650,6 +2650,17 @@ additionalEffectiveRectOfDividerAtIndex:(NSInteger)dividerIndex
 	return nil;
 }
 
+- (id)ex_bang:(ExCommand *)command
+{
+	// We only deal with zero-argument :! commands here.
+	if (command.naddr > 0)
+		return nil;
+
+	NSLog(@"And here we are...");
+
+	return nil;
+}
+
 - (id)ex_set:(ExCommand *)command
 {
 	NSDictionary *variables = [NSDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
Currently :! commands only work as filters (i.e., when given a number
of lines to work with). We want them to work without filters as well, displaying their output somewhere reasonable.
