### PR TITLE
Make window opaque to normalize shadow.

### DIFF
--- a/app/ViWindowController.m
+++ b/app/ViWindowController.m
@@ -253,7 +253,6 @@ DEBUG_FINALIZE();
 	[tabBar setShowAddTabButton:YES];
 	[tabBar setAllowsDragBetweenWindows:NO]; // XXX: Must update for this to work without NSTabview
 
-	[[self window] setOpaque:NO];
 	[[self window] setDelegate:self];
 	[[self window] setFrameUsingName:@"MainDocumentWindow"];
 


### PR DESCRIPTION
This takes the transparency out of windows, which was probably there to allow for alpha channels in theme backgrounds, but was also making for a lighter window shadow that made the app feel off from other native apps.
