### PR TITLE
Now You See Me: Toggle window opacity based on theme background.

### DIFF
--- a/app/ViWindowController.m
+++ b/app/ViWindowController.m
@@ -436,6 +436,13 @@ DEBUG_FINALIZE();
 	} else {
 		[[self window] setOpaque:YES];
 	}
+
+	NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
+	if (keyWindow != [self window]) {
+		[[self window] makeKeyWindow];
+
+		[keyWindow makeKeyWindow];
+	}
 }
 
 - (void)addDocument:(ViDocument *)document


### PR DESCRIPTION
This is a more complete fix for #63, toggling a window's opacity setting based on the theme background's alpha channel.

I will confess to not having tested it, and I will confess I haven't tested vico before these changes either to see if it actually correctly implements transparent backgrounds. I'll give it more love if anyone gives any specific feedback here, but otherwise we'll stick to this solution until I hear from someone who actually needs it that it doesn't work ;)
