### PR TITLE
Adaptive UI Colors

### DIFF
--- a/app/ViLineNumberView.h
+++ b/app/ViLineNumberView.h
@@ -18,9 +18,11 @@
 	ViTextView 		*_textView;
 }
 
-@property (nonatomic,readwrite) NSColor *backgroundColor;
+@property (nonatomic,readwrite,strong) NSColor *backgroundColor;
+@property (nonatomic,readwrite,strong) NSColor *foregroundColor;
+@property (nonatomic,readwrite,strong) NSColor *borderColor;
 
-- (ViLineNumberView *)initWithTextView:(ViTextView *)aTextView backgroundColor:(NSColor *)aColor;
+- (ViLineNumberView *)initWithTextView:(ViTextView *)aTextView;
 
 - (void)setRelative:(BOOL)flag;
 - (void)setTextView:(ViTextView *)aTextView;

--- a/app/ViRulerView.m
+++ b/app/ViRulerView.m
@@ -81,8 +81,7 @@
 		if (_lineNumberView) {
 			[_lineNumberView setTextView:(ViTextView *)aView];
 		} else {
-			_lineNumberView = [[ViLineNumberView alloc] initWithTextView:(ViTextView *)aView
-														 backgroundColor:_backgroundColor];
+			_lineNumberView = [[ViLineNumberView alloc] initWithTextView:(ViTextView *)aView];
 
 			[[NSNotificationCenter defaultCenter] addObserver:self
 													 selector:@selector(subviewFrameDidChange:)

--- a/app/ViTextView.m
+++ b/app/ViTextView.m
@@ -2676,6 +2676,12 @@ replaceCharactersInRange:(NSRange)aRange
 								    forKey:NSBackgroundColorAttributeName]];
 
 	backgroundIsDark = [aTheme hasDarkBackground];
+	if (backgroundIsDark) {
+		[[self enclosingScrollView] setScrollerKnobStyle:NSScrollerKnobStyleLight];
+	} else {
+		[[self enclosingScrollView] setScrollerKnobStyle:NSScrollerKnobStyleDark];
+	}
+	
 	[self setCursorColor];
 }
 

--- a/app/ViTheme.h
+++ b/app/ViTheme.h
@@ -52,6 +52,8 @@
 - (NSColor *)lineHighlightColor;
 - (NSColor *)selectionColor;
 - (NSColor *)invisiblesColor;
+- (NSColor *)lineNumberBackgroundColor;
+- (NSColor *)lineNumberForegroundColor;
 - (NSString *)description;
 - (BOOL)hasDarkBackground;
 

--- a/app/ViTheme.m
+++ b/app/ViTheme.m
@@ -272,9 +272,30 @@
 	                                   forKey:NSForegroundColorAttributeName];
 }
 
+- (NSColor *)lineNumberForegroundColor
+{
+	if ([self hasDarkBackground]) {
+		return [NSColor colorWithCalibratedWhite:0.75 alpha:1.0];
+	} else {
+		return [NSColor colorWithCalibratedWhite:0.25 alpha:1.0];
+	}
+}
+
+- (NSColor *)lineNumberBackgroundColor
+{
+	NSColor* blend;
+	
+	if ([self hasDarkBackground]) {
+		blend = [NSColor whiteColor];
+	} else {
+		blend = [NSColor blackColor];
+	}
+	return [[self backgroundColor] blendedColorWithFraction:0.04 ofColor:blend];
+}
+
 - (BOOL)hasDarkBackground
 {
-	return ([[self backgroundColor] brightnessComponent] < 0.6);
+	return ([[self backgroundColor] brightnessComponent] < 0.55);
 }
 
 - (NSString *)description


### PR DESCRIPTION
This PR is supposed to make dark themes usable with Vico. I find the light gray UI elements very distracting when working with a dark theme, especially in full screen mode.

Don't merge this yet. My current plan is to do the same thing to the dividers and maybe even the sidebars.
Would you accept such a change?

**Without adaptive line number colors:**
![vico-line-numbers-before](https://f.cloud.github.com/assets/6915/2179787/2903b600-96d8-11e3-8e13-a5eb32c159a6.png)

**With adaptive number colors:**
![vico-line-numbers-after](https://f.cloud.github.com/assets/6915/2179786/28c993b2-96d8-11e3-808b-d80461c856c9.png)
