### PR TITLE
Flippety Floppety Floo: Handle icon flippedness correctly everywhere.

### DIFF
--- a/app/MHTextIconCell.m
+++ b/app/MHTextIconCell.m
@@ -115,11 +115,6 @@
 		imageFrame.origin.x += 3;
 		imageFrame.size = imageSize;
 
-		if ([controlView isFlipped])
-			imageFrame.origin.y += ceil((cellFrame.size.height + imageFrame.size.height) / 2);
-		else
-			imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
-
 		[_image drawAtPoint:imageFrame.origin fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
 	}
 

--- a/app/PSMMetalTabStyle.m
+++ b/app/PSMMetalTabStyle.m
@@ -385,9 +385,6 @@
 		}
 
 		closeButtonSize = [closeButton size];
-		if ([controlView isFlipped]) {
-			closeButtonRect.origin.y += closeButtonRect.size.height;
-		}
 
 		[closeButton drawAtPoint:closeButtonRect.origin fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
 
@@ -399,9 +396,6 @@
 	if([cell hasIcon]){
 		NSRect iconRect = [self iconRectForTabCell:cell];
 		NSImage *icon = [[[(NSTabViewItem *)[cell representedObject] identifier] content] icon];
-		if ([controlView isFlipped]) {
-			iconRect.origin.y = cellFrame.size.height - iconRect.origin.y;
-		}
 		[icon drawAtPoint:iconRect.origin fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
 
 		// scoot label over

--- a/app/PSMOverflowPopUpButton.m
+++ b/app/PSMOverflowPopUpButton.m
@@ -36,10 +36,7 @@
 	NSSize imageSize = [image size];
     rect.origin.x = NSMidX(rect) - (imageSize.width * 0.5);
     rect.origin.y = NSMidY(rect) - (imageSize.height * 0.5);
-    if([self isFlipped]) {
-        rect.origin.y += imageSize.height;
-    }
-	[image drawAtPoint:rect.origin fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
+    [image drawAtPoint:rect.origin fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
 }
 
 - (void)mouseDown:(NSEvent *)event

--- a/app/ViToolbarPopUpButtonCell.m
+++ b/app/ViToolbarPopUpButtonCell.m
@@ -31,7 +31,6 @@
 - (void)setImage:(NSImage *)anImage
 {
 	_image = anImage;
-	[_image setFlipped:YES];
 }
 
 


### PR DESCRIPTION
There was a call to flip images being rendered in ViToolbarPopUpButtonCell that
was breaking all drawing using drawAtPoint:, which we switched to in order to
avoid deprecation warnings on compositeToPoint:.

This removes all weird flippedness handling in the code and the original flip
in the final drawing component.

Fixes #84 .