### PR TITLE
import help pages scraped from website

### DIFF
--- a/doc/help/en/basics.html
+++ b/doc/help/en/basics.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Editing Basics</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Editing Basics</h1>
+
+<p>Vico is a modal editor. This means there are different modes
+in which you interact with the editor. The most fundamental modes
+are the insert mode and normal mode. Regular keys pressed while
+in insert mode causes text to be inserted. In contrast, while in
+normal mode, regular keys are attached to editing commands such as
+delete, change or copy text.</p>
+
+<p>If you have used the <kbd>vi</kbd> or <kbd>vim</kbd> text editors,
+you should feel comfortable with Vico. If this is your first encounter
+with a modal editor, you might feel a bit overwhelmed at first. But
+if you give it some time and learn the basics, you'll be rewarded with
+a highly efficient text editing tool.</p>
+
+<ul>
+<li><a href="insert.html">Inserting text</a></li>
+<li><a href="movement.html">Movement Commands</a></li>
+<li><a href="delete.html">Deleting text</a></li>
+<li><a href="change.html">Changing text</a></li>
+<li><a href="operators.html">Operator Commands</a></li>
+<li><a href="dot.html">Repeating changes</a></li>
+<li><a href="searching.html">Searching</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/change.html
+++ b/doc/help/en/change.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Changing text</title>
+</head>
+<body>
+
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Changing text</h1>
+
+<p>The <kbd>c</kbd> (change) <a href="operators.html">operator</a> deletes the affected text
+and enters insert mode. The <kbd>cw</kbd> is one of the most used commands: it
+changes one word. The change command is not considered complete until you exit
+insert mode with <kbd>&#x238B;</kbd> (escape). Back in normal mode, you can
+repeat the change with the <a href="dot.html">dot command</a>.</p>
+
+<p>The (uppercase) <kbd>C</kbd> command deletes from the current location
+to the end of the line, and then enters insert mode. It is the same as
+<kbd>c$</kbd>.</p>
+
+<p>Use the <kbd>r</kbd> (replace) command to change a single character. Vico waits
+for you to type the new character. In <a href="visual.html">visual mode</a>, the
+<kbd>r</kbd> command changes the whole selection to the same character.</p>
+
+<p>The <kbd>s</kbd> (substitute) command replaces one, or, given a count,
+that many characters and then enters insert mode. The uppercase variant
+<kbd>S</kbd> is line-oriented and replaces one or more lines.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/change_indent.html
+++ b/doc/help/en/change_indent.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Changing indentation</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Changing indentation</h1>
+
+<p>While in insert mode, use the <kbd>ctrl-t</kbd> and <kbd>ctrl-d</kbd> commands
+to increase and decrease the indentation level of the current line.</p>
+
+<p>To manually shift a block of text left or right, use the <kbd>&lt;</kbd> and
+<kbd>&gt;</kbd> <a href="operators.html">operators</a>. It's easy to use them in
+<a href="visual.html">visual mode</a> by first selecting the text that should be indented.</p>
+
+<p>The <kbd>=</kbd> command can be used to automatically indent text based on
+the current language syntax.</p>
+
+<p>The above commands uses the indentation settings for the current scope to
+determine how to indent.</p>
+
+<ul>
+<li><a href="indent_settings.html">Indentation settings</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/delete.html
+++ b/doc/help/en/delete.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Deleting text</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Deleting text</h1>
+
+<p>The simplest deletion command is <kbd>x</kbd>. It deletes the character under
+the caret. A count before deletes that many characters, e.g. <kbd>10x</kbd>
+deletes 10 characters. Similarly, the <kbd>X</kbd> command deletes one character
+to the left of the caret.</p>
+
+<p>The <kbd>D</kbd> command deletes from the current location to the end of the
+line.</p>
+
+<p>The <kbd>d</kbd> command is an <a href="operators.html">operator</a> and thus must be
+combined with a motion command. For example, <kbd>dw</kbd> deletes a word,
+<kbd>d3W</kbd> deletes 3 big words, and <kbd>dd</kbd> deletes the current line.</p>
+
+<p>The <kbd>c</kbd> (change) command is similar to the <kbd>d</kbd> command, but
+also enters insert mode.</p>
+
+<ul>
+<li><a href="change.html">Changing text</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/dot.html
+++ b/doc/help/en/dot.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Repeating the last change</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Repeating the last change</h1>
+
+<p>One of the most powerful vi commands is the dot command. The dot command
+(<kbd>.</kbd>) simply repeats the last change. </p>
+
+<p>You can move around without overwriting the dot command.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/ex.html
+++ b/doc/help/en/ex.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>The ex command line</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>The ex command line</h1>
+
+<p>The ex command line is normally hidden under the status bar at the
+bottom of the window. The command line is used to enter ex commands
+(<kbd>:</kbd>), filter commands (<kbd>!</kbd>) and search patterns
+(<kbd>/</kbd> and <kbd>?</kbd>).</p>
+
+<p>Lines entered on the command line are remembered in a history. Use up and
+down arrows to recall history.</p>
+
+<ul>
+<li><a href="ex_ranges.html">Ex ranges</a></li>
+<li><a href="ex_cmds.html">Ex commands</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/ex_cmds.html
+++ b/doc/help/en/ex_cmds.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Ex commands</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Ex commands</h1>
+
+<p>The following <a href="ex.html">ex</a> commands are available:</p>
+
+<ul>
+<li><kbd>:!</kbd> <shell command> &mdash; filter lines through shell command</li>
+<li><kbd>:b[uffer]</kbd> <name> &mdash; switch current view to another document</li>
+<li><kbd>:bd[elete]</kbd> &mdash; close the current document, opens an untitled file if last document closed</li>
+<li><kbd>:cd</kbd> <directory> &mdash; change current working directory</li>
+<li><kbd>:close</kbd> &mdash; close the current view</li>
+<li><kbd>:copy address</kbd> &mdash; copy the affected line range to the target line address</li>
+<li><kbd>:delete</kbd> <filename> &mdash; delete affected line range, or current line by default</li>
+<li><kbd>:edit</kbd> <filename> &mdash; edit a new file</li>
+<li><kbd>:eval</kbd> &mdash; evaluate the affected lines (or the current line) as a Nu expression</li>
+<li><kbd>:export</kbd> var=[value] &mdash; export an environment variable</li>
+<li><kbd>:move address</kbd> &mdash; move the affected line range to the target line address</li>
+<li><kbd>:new</kbd> &mdash; edit a new file in a new horizontal split</li>
+<li><kbd>:pwd</kbd> &mdash; show the current working directory</li>
+<li><kbd>:quit</kbd> &mdash; close the current document, closes the window if last document closed</li>
+<li><kbd>:s</kbd> /RE/replacement/[g] &mdash; replace lines matching RE with replacement</li>
+<li><kbd>:sbuffer</kbd> <filename> &mdash; split view horizontally and edit another open document</li>
+<li><kbd>:set</kbd> option[=value] &mdash; set an option</li>
+<li><kbd>:setfiletype</kbd> <syntax> &mdash; change the language syntax of the document</li>
+<li><kbd>:split</kbd> [filename] &mdash; split the current view horizontally, and optionally edit another file</li>
+<li><kbd>:t address</kbd> <filename> &mdash; alias for <code>:copy</code></li>
+<li><kbd>:tabedit</kbd> <filename> &mdash; edit another file in a new tab</li>
+<li><kbd>:tabnew</kbd> &mdash; edit a new file in a new tab</li>
+<li><kbd>:tbuffer</kbd> <filename> &mdash; switch to a tab showing <filename>, or open a new tab</li>
+<li><kbd>:vbuffer</kbd> <filename> &mdash; split view vertically and edit another open document</li>
+<li><kbd>:vnew</kbd> &mdash; edit a new file in a new vertical split</li>
+<li><kbd>:vsplit</kbd> [filename] &mdash; split the current view vertically, and optionally edit another file</li>
+<li><kbd>:w[rite]</kbd> [new filename] &mdash; save the document, optionally with a new name</li>
+<li><kbd>:wq</kbd> &mdash; write the document and close it</li>
+<li><kbd>:x[it]</kbd> &mdash; write the document and close it</li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/ex_ranges.html
+++ b/doc/help/en/ex_ranges.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Ex command ranges</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Ex command ranges</h1>
+
+<p>Many <a href="ex_cmds.html">ex commands</a> accept a range of lines to operate
+upon. The range precede the command name and consists of zero, one or
+two line addresses separated with comma. </p>
+
+<p>A line address can be written as:</p>
+
+<ul>
+<li>an absolute line number, ie <kbd>3</kbd></li>
+<li><kbd>$</kbd> denotes the last line</li>
+<li><kbd>.</kbd> (a dot) referes to the current line</li>
+<li>a mark (eg <kbd>'x</kbd>)</li>
+<li><kbd>%</kbd> denotes all lines, same as <kbd>1,$</kbd></li>
+<li>a forward search pattern, delimited by slashes, eg <kbd>/foo/</kbd></li>
+<li>a backward search pattern, delimited by question marks, eg <kbd>?foo?</kbd></li>
+</ul>
+
+<p>Additionally, a line offset may be appended to a line address with
+<kbd>+</kbd> or <kbd>-</kbd>. For example, <kbd>.+2</kbd> means two
+lines after the current line.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/explorer.html
+++ b/doc/help/en/explorer.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Using the file explorer</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Using the file explorer</h1>
+
+<p>Activate the file explorer with the <kbd>&#x2318;E</kbd> key. When the explorer
+has focus, you can navigate using many of the regular
+<a href="movement.html">vi motion keys</a>.</p>
+
+<p>To open a file, select the file and press <kbd>t</kbd>, <kbd>s</kbd>,
+<kbd>v</kbd> or <kbd>o</kbd> to open it in a tab, a split view, a vertical
+split, or replace the current document, respectively. Pressing
+<kbd>enter</kbd> opens the selected file in a tab or in the current
+split view, depending on the preferences.</p>
+
+<p>Here is a list of all key mappings in the explorer:</p>
+
+<ul>
+<li><kbd>h</kbd> &mdash; move up the tree hierarchy, closing subdirectories</li>
+<li><kbd>l</kbd> &mdash; move down the tree hierarchy, opening subdirectories</li>
+<li><kbd>j</kbd> &mdash; move down</li>
+<li><kbd>k</kbd> &mdash; move up</li>
+<li><kbd>&lt;ctrl-b&gt;</kbd> &mdash; scroll up one screen</li>
+<li><kbd>&lt;ctrl-f&gt;</kbd> &mdash; scroll down one screen</li>
+<li><kbd>&lt;ctrl-e&gt;</kbd> &mdash; scroll down one line</li>
+<li><kbd>&lt;ctrl-y&gt;</kbd> &mdash; scroll up one line</li>
+<li><kbd>G</kbd> &mdash; move to the last line (or a specific line with a count)</li>
+<li><kbd>gg</kbd> &mdash; move to the first line (or a specific line with a count)</li>
+<li><kbd>H</kbd> &mdash; move to top line ("<strong>H</strong>igh")</li>
+<li><kbd>M</kbd> &mdash; move to <strong>m</strong>iddle line</li>
+<li><kbd>L</kbd> &mdash; move to bottom line ("<strong>L</strong>ow")</li>
+<li><kbd>/</kbd> &mdash; search</li>
+<li><kbd>&lt;esc&gt;</kbd> &mdash; cancel and go back</li>
+<li><kbd>&lt;ctrl-c&gt;</kbd> &mdash; cancel and go back, or reset the search filter</li>
+<li><kbd>o</kbd> &mdash; open the selected file in the current view</li>
+<li><kbd>s</kbd> &mdash; open the selected file in a split view</li>
+<li><kbd>v</kbd> &mdash; open the selected file in a vertical split view</li>
+<li><kbd>t</kbd> &mdash; open the selected file in a new tab</li>
+<li><kbd>N</kbd> &mdash; create a new directory</li>
+<li><kbd>r</kbd> &mdash; rename the selected file</li>
+<li><kbd>dd</kbd> &mdash; delete the selected files</li>
+<li><kbd>&lt;ctrl-o&gt;</kbd> &mdash; navigate back in the browse history</li>
+<li><kbd>&lt;ctrl-i&gt;</kbd> &mdash; navigate forward in the browse history</li>
+<li><kbd>&lt;ctrl-l&gt;</kbd> &mdash; rescan files in the selected directory</li>
+<li><kbd>&lt;ctrl-esc&gt;</kbd> or <kbd>&lt;cmd-esc&gt;</kbd> &mdash; show action menu</li>
+<li><kbd>&lt;cmd-up&gt;</kbd> &mdash; navigate to the parent directory</li>
+<li><kbd>&lt;cmd-down&gt;</kbd> or <kbd>&lt;enter&gt;</kbd> &mdash; navigate to the selected directory, or open the selected file</li>
+<li><kbd>&lt;cmd-H&gt;</kbd> &mdash; navigate to the local home directory</li>
+<li><kbd>&lt;cmd-D&gt;</kbd> &mdash; navigate to the local Desktop directory</li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/indent_settings.html
+++ b/doc/help/en/indent_settings.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Settings for indentation</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Settings for indentation</h1>
+
+<p>The <kbd>shiftwidth</kbd> setting controls how large an indentation is in terms
+of spaces. This is different from the <kbd>tabstop</kbd> setting that specifies
+how large an actual tab character is.</p>
+
+<p>If <kbd>shiftwidth</kbd> is set to 4 and <kbd>tabstop</kbd> is left at the
+default 8, one indentation will use 4 spaces, but two indentations will use one
+tab.</p>
+
+<p>Use the <kbd>expandtab</kbd> setting to always use spaces when indenting.</p>
+
+<p>When the <kbd>autoindent</kbd> setting is enabled, a new line will use the same
+amount of indentation as the previous line. The <kbd>smartindent</kbd> setting
+adds syntax-aware rules for increasing and decreasing the automatic indentation.</p>
+
+<ul>
+<li><a href="change_indent.html">Changing indentation</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/index.html
+++ b/doc/help/en/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Index</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Help Index</h1>
+
+<ul>
+<li><a href="basics.html">Editing Basics</a></li>
+<li><a href="change.html">Changing text</a></li>
+<li><a href="change_indent.html">Changing indentation</a></li>
+<li><a href="delete.html">Deleting text</a></li>
+<li><a href="dot.html">Repeating the last change</a></li>
+<li><a href="ex.html">The ex command line</a></li>
+<li><a href="ex_cmds.html">Ex commands</a></li>
+<li><a href="ex_ranges.html">Ex command ranges</a></li>
+<li><a href="explorer.html">Using the file explorer</a></li>
+<li><a href="indent_settings.html">Settings for indentation</a></li>
+<li><a href="insert.html">Inserting text</a></li>
+<li><a href="jumplist.html">The jumplist</a></li>
+<li><a href="line_search.html">Searching within a line</a></li>
+<li><a href="move_chars.html">Moving by characters</a></li>
+<li><a href="move_lines.html">Moving by lines</a></li>
+<li><a href="move_symbols.html">Moving by symbols</a></li>
+<li><a href="move_words.html">Moving by words</a></li>
+<li><a href="movement.html">Movement commands</a></li>
+<li><a href="open_line.html">Opening lines</a></li>
+<li><a href="operators.html">Operator commands</a></li>
+<li><a href="remote.html">Working with remote files</a></li>
+<li><a href="scrolling.html">Scrolling the screen</a></li>
+<li><a href="searching.html">Searching</a></li>
+<li><a href="splits.html">Working with split views</a></li>
+<li><a href="ssh_keygen.html">Creating a key for SFTP</a></li>
+<li><a href="symbols.html">The symbol list</a></li>
+<li><a href="terminal.html">Terminal usage</a></li>
+<li><a href="visual.html">Visual mode</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/insert.html
+++ b/doc/help/en/insert.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Inserting text</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Inserting text</h1>
+
+<p>To insert text you must first enter insert mode. The most basic way to
+enter insert mode is with the <kbd>i</kbd> (insert) command. You will
+notice you are in insert mode when the caret changes from a block caret
+to a thin caret.</p>
+
+<p>When you are done inserting text, press the <kbd>&#x238B;</kbd>
+(escape) key to go back to normal mode.</p>
+
+<p>The <kbd>i</kbd> command enters insert mode at the current location.
+To enter insert mode <em>after</em> the current location, you use the <kbd>a</kbd>
+(append) command.</p>
+
+<p>If you want to append text to the end of the current line, no matter where
+on the line you are, use the <kbd>A</kbd> command.</p>
+
+<p>Similarly, the <kbd>I</kbd> command moves to the first non-blank character
+on the current line and enters insert mode there.</p>
+
+<ul>
+<li><a href="open_line.html">Opening new lines</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/jumplist.html
+++ b/doc/help/en/jumplist.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>The jumplist</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>The jumplist</h1>
+
+<p>Vico maintains a list of locations while you move around in files. Some movement
+commands are considered "jumps", and those jumps are remembered in a list.</p>
+
+<p>Generally, movement commands that generate jumps are those that
+move more than a few lines. So the <a href="move_words.html">word</a>,
+<a href="move_chars.html">character</a> and <a href="line_search.html">line search</a>
+motion commands do not generate a jump, but the <a href="move_lines.html">line</a>
+and <a href="searching.html">search</a> motions do.</p>
+
+<p>You navigate the jumplist either by pressing the jumplist arrows in the toolbar,
+or pressing <kbd>ctrl-o</kbd> to go back and <kbd>ctrl-i</kbd>
+(or <kbd>tab</kbd>) to go forward. </p>
+
+<p>Only the last 100 jumps are remembered, and duplicates are removed.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/line_search.html
+++ b/doc/help/en/line_search.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Searching within a line</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Searching within a line</h1>
+
+<p>To quickly search for the next or previous occurrance of a character on the
+current line, you can use the <kbd>f</kbd> or <kbd>F</kbd> commands. The lowercase
+<kbd>f</kbd> command moves forward, while the uppercase <kbd>F</kbd> command
+moves backwards.</p>
+
+<p>After you've pressed the <kbd>f</kbd> key, Vico waits for you to enter another
+character. This is the character to search for. For example, the command
+<kbd>f:</kbd> searches for the next occurrance of a colon on the current line.</p>
+
+<p>The <kbd>t</kbd> and <kbd>T</kbd> commands works similarly, but instead of
+moving exactly to the specified character, it stops just before.</p>
+
+<p>The last character searched for with those commands is remembered, and the
+search can be repeated with the <kbd>;</kbd> (semicolon) and <kbd>,</kbd>
+(comma) commands. They repeat the search in the same and opposite direction,
+respectively.</p>
+
+<ul>
+<li><a href="searching.html">Searching</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/move_chars.html
+++ b/doc/help/en/move_chars.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Moving by characters</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Moving by characters</h1>
+
+<p>To move one character to the left, you either use the arrow key, or the
+<kbd>h</kbd> command. The <kbd>l</kbd> command move to the right.</p>
+
+<p>The <kbd>j</kbd> and <kbd>k</kbd> commands move one line down and up,
+respectively.</p>
+
+<p>To help you remember which key move in what direction, think of <kbd>h</kbd>
+being the leftmost key among these, and <kbd>l</kbd> the rightmost.
+The <kbd>j</kbd> key can be thought of a downward pointing arrow, and, with a
+little imagination, the lowercase <kbd>k</kbd> is pointing upwards.</p>
+
+<ul>
+<li><a href="movement.html">Movement</a></li>
+<li><a href="line_search.html">Line searching</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/move_lines.html
+++ b/doc/help/en/move_lines.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Moving by lines</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Moving by lines</h1>
+
+<p>You can jump to the top, middle and bottom line of the screen with the
+<kbd>H</kbd>, <kbd>M</kbd> and <kbd>L</kbd> commands. To remember them,
+you can think of <kbd>H</kbd> as the <strong>H</strong>igh line, and <kbd>L</kbd> as
+the <strong>L</strong>ow line.</p>
+
+<p>The <kbd>}</kbd> and <kbd>{</kbd> commands move by paragraphs. A
+paragraph is considered delimited by an empty line.</p>
+
+<p>The <kbd>G</kbd> command jumps to the last line. With a count, it jumps
+to that line number. For example, <kbd>10G</kbd> jumps to line number
+10. The <kbd>gg</kbd> command is similar to <kbd>G</kbd>, but defaults
+to the first line if no count is given.</p>
+
+<ul>
+<li><a href="movement.html">Movement</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/move_symbols.html
+++ b/doc/help/en/move_symbols.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Moving by symbols</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Moving by symbols</h1>
+
+<p>The <kbd>ctrl-]</kbd> key (in normal mode), jumps to the symbol under the caret.</p>
+
+<p>If you have a <a href="http://ctags.sourceforge.net/">tags</a> file, Vico will try to
+lookup the current word as a tag. The <code>tags</code> file should be placed in
+the windows current directory, ie the top-most directory displayed by
+the <a href="explorer.html">explorer</a>.</p>
+
+<p>If no tag was found, Vico tries to match the current word with a
+<a href="symbols.html">symbol</a>. If more than one match is found, you are presented with
+a menu.</p>
+
+<p>If a tag or symbol is found, the current location is pushed on the
+<a href="tagstack.html">tag stack</a>, and the caret is jumped to the new location.
+Press <kbd>ctrl-t</kbd> to go back.</p>
+
+<p>You can also use the <kbd>&#x21E7;&#x2318;T</kbd> key to search the
+<a href="symbols.html">symbol list</a>.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/move_words.html
+++ b/doc/help/en/move_words.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Moving by words</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Moving by words</h1>
+
+<p>To move to the next word, use the <kbd>w</kbd> command.</p>
+
+<p>The <kbd>w</kbd> command considers separator characters when deciding where the
+next word starts. To only consider whitespace as word separators, you can use
+the (uppercase) <kbd>W</kbd> command.</p>
+
+<p>To move in the opposite direction, use the <kbd>b</kbd> command to move over a
+normal word, and the capital <kbd>B</kbd> command to move over "big words".</p>
+
+<p>There is also the <kbd>e</kbd> and <kbd>E</kbd> commands that move to the <em>end</em>
+of the next word or bigword.</p>
+
+<p>If you prefix the above commands with a number, the command will move that many
+words. For example, the command <kbd>3w</kbd> will move three words to the right.</p>
+
+<ul>
+<li><a href="movement.html">Movement</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/movement.html
+++ b/doc/help/en/movement.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Movement commands</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Movement commands</h1>
+
+<p>You can use the normal arrow, page up and page down keys in Vico to move around.
+But there are more movement commands available in vi than there are cursor keys.
+And with the vi way of navigating, you don't have to reach all the way across
+the keyboard.</p>
+
+<p>Most vi tutorials begin with describing the <kbd>hjkl</kbd> keys for moving
+left, down, up and right. If you're new to vi, you may want to wait with them.
+They do feel a bit awkward at first, but once you've learned to use them, you
+realize they aren't so bad at all.</p>
+
+<ul>
+<li><a href="move_words.html">Moving by words</a></li>
+<li><a href="move_chars.html">Moving by characters</a></li>
+<li><a href="move_lines.html">Moving by lines</a></li>
+<li><a href="move_symbols.html">Moving by symbols</a></li>
+<li><a href="jumplist.html">Moving back to previous locations</a></li>
+<li><a href="searching.html">Searching</a></li>
+<li><a href="scrolling.html">Scrolling the screen</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/operators.html
+++ b/doc/help/en/operators.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Operator commands</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Operator commands</h1>
+
+<p>Some commands must be combined with a motion command to be complete. These
+commands are called operators, as they operate on the text affected by the
+motion command.</p>
+
+<p>The standard operator commands are:</p>
+
+<ul>
+<li><kbd>d</kbd> -- delete</li>
+<li><kbd>c</kbd> -- change</li>
+<li><kbd>y</kbd> -- yank, or copy</li>
+<li><kbd>=</kbd> -- indent</li>
+<li><kbd>&lt;</kbd> -- shift left</li>
+<li><kbd>&gt;</kbd> -- shift right</li>
+<li><kbd>!</kbd> -- filter through external command</li>
+<li><kbd>gu</kbd> -- lowercase</li>
+<li><kbd>gU</kbd> -- uppercase</li>
+<li><kbd>gq</kbd> -- format text</li>
+</ul>
+
+<p>You combine the operator with a motion just by entering the motion command
+after the operator. For example, <kbd>cw</kbd> <strong>c</strong>hanges a <strong>w</strong>ord.</p>
+
+<p>All operator commands can be doubled to imply the current line. This way,
+<kbd>dd</kbd> deletes the current line, <kbd>&gt;&gt;</kbd> shift the current
+line one <a href="indent_settings.html">shiftwidth</a> to the right and <kbd>yy</kbd>
+copies (yanks) the line.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/remote.html
+++ b/doc/help/en/remote.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><script
+  <meta charset="utf-8"/>
+  <title>Working with remote files</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Working with remote files</h1>
+
+<p>Vico has built-in support for editing files over SFTP. To open a remote directory,
+use the <kbd>:cd</kbd> command to change to a <kbd>sftp://</kbd> URL. For
+example, <kbd>:cd sftp://www.example.com</kbd> changes to the home directory on
+the <kbd>www.example.com</kbd> server. Use the <a href="explorer.html">explorer</a>
+sidebar to open files, or directly with the <kbd>:edit</kbd> command.</p>
+
+<p>A file relative to the home directory on the remote server can be referenced
+by the following URL: <kbd>sftp://www.example.com/~/directory/file.txt</kbd></p>
+
+<p>For SFTP to work, you must use public key authentication. It is recommended
+that you protect your private key with a passphrase.</p>
+
+<p>Vico's SFTP support uses the ssh support built-in to Mac OS X, so any
+configuration files you already have for ssh will be used.</p>
+
+<ul>
+<li><a href="ssh_keygen.html">Creating a key for SFTP</a></li>
+<li><a href="ex.html">ex command line</a></li>
+<li><a href="http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man5/ssh_config.5.html">ssh_config(5) manual page</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/scrolling.html
+++ b/doc/help/en/scrolling.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Scrolling the screen</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Scrolling the screen</h1>
+
+<p><kbd>Ctrl-f</kbd> and <kbd>Ctrl-b</kbd> (in normal mode) scroll the
+screen one page <strong>f</strong>orward and <strong>b</strong>ackward.</p>
+
+<p>The <kbd>Ctrl-d</kbd> and <kbd>Ctrl-u</kbd> commands scroll the screen
+one half screen page <strong>d</strong>own and <strong>u</strong>p, respectively.</p>
+
+<p>To reposition the screen relative the current caret location, the
+<kbd>zz</kbd> command centers the caret on the screen, <kbd>zt</kbd>
+puts the caret at the top of the screen, and <kbd>zb</kbd> at the bottom.</p>
+
+<ul>
+<li><a href="movement.html">Movement</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/searching.html
+++ b/doc/help/en/searching.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Searching</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Searching</h1>
+
+<p>To search, use the <kbd>/</kbd> command and enter a regular expression
+in the command line at the bottom of the window. This command is also
+available by the standard <kbd>&#x2318;F</kbd> key.</p>
+
+<p>If the <kbd>ignorecase</kbd> option is set, case is ignored. If the
+<kbd>smartcase</kbd> option is also set, case is ignored only if the
+search pattern does not include any uppercase characters.</p>
+
+<p>To search backwards, use <kbd>?</kbd>.</p>
+
+<p>To quickly search for the word under the caret, use <kbd>*</kbd>. The
+<kbd>#</kbd> command searches backwards instead.</p>
+
+<p>You can repeat the last seach command in the same direction with the
+<kbd>n</kbd> command. The upper case <kbd>N</kbd> command reverses the
+direction.</p>
+
+<ul>
+<li><a href="movement.html">Movement</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/splits.html
+++ b/doc/help/en/splits.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Working with split views</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Working with split views</h1>
+
+<p>Vico can show the same or different documents side by side in split views.
+Views can be split either horizontally or vertically. There is no limit on the
+number of splits you can create, but more than a couple in the same tab tends to
+be hard to manage.</p>
+
+<p>Most keys that manages split views begin with <kbd>&lt;ctrl-w&gt;</kbd>.
+To split the current view, use the <kbd>&lt;ctrl-w&gt;s</kbd> command, ie first
+press <kbd>&lt;ctrl-w&gt;</kbd> and then press the <kbd>s</kbd> key. If you use
+<kbd>v</kbd> instead, you get a vertical split.</p>
+
+<p>If you want to move a split view to a new tab, use <kbd>&lt;ctrl-w&gt;T</kbd>.</p>
+
+<p>To navigate between split views, use <kbd>&lt;ctrl-w&gt;</kbd> followed
+by a vi motion key (<kbd>hjkl</kbd>) or one of the arrow keys. The
+<kbd>&lt;ctrl-w&gt;w</kbd> command moves to the next split view. The
+<kbd>&lt;ctrl-w&gt;W</kbd> moves to the previous split view. Use
+<kbd>&lt;ctrl-w&gt;p</kbd> to toggle between the last focused split view.</p>
+
+<p>The <a href="explorer.html">explorer</a> and <a href="symbols.html">symbol list</a> can also be used
+to open files or symbols in split views.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/ssh_keygen.html
+++ b/doc/help/en/ssh_keygen.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Creating a key for SFTP</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Creating a key for SFTP</h1>
+
+<p>To create a public/private key for SFTP (or ssh in general), you need to open
+Terminal.app and run the <kbd>ssh-keygen</kbd> command:</p>
+
+<pre><code>ssh-keygen -t rsa
+</code></pre>
+
+<p>It should look something like this;</p>
+
+<pre><code>martinh@macbookpro:~$ ssh-keygen -t rsa
+Generating public/private rsa key pair.
+Enter file in which to save the key (/Users/martinh/.ssh/id_rsa):
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in /Users/martinh/.ssh/id_rsa.
+Your public key has been saved in /Users/martinh/.ssh/id_rsa.pub.
+The key fingerprint is:
+77:15:d9:55:4f:b9:01:90:2c:48:ae:3b:39:22:52:fa martinh@macbookpro.local
+The key's randomart image is:
++--[ RSA 2048]----+
+|      ... ..o.ooB|
+|      .. . o  .=o|
+|       .  .   . +|
+|      .      . . |
+|  .  .  S . .    |
+| o    o  . .     |
+|o. . =           |
+|... . o          |
+|  E              |
++-----------------+
+martinh@macbookpro:~$
+</code></pre>
+
+<p>Make sure you use a good passphrase. If you leave the passphrase empty, anyone
+with access to your key file have access to any remote server you authorize with
+that key.</p>
+
+<p>To authorize a remote server to log you in with this key, you copy the
+<em>public key</em> to the <kbd>~/.ssh/authorized_keys</kbd> file on the remote server:</p>
+
+<pre><code>cat ~/.ssh/id_rsa.pub | ssh hostname 'mkdir -m700 -p .ssh &amp;&amp; cat &gt;&gt; .ssh/authorized_keys'
+</code></pre>
+
+<p>The above command makes sure the remote <kbd>.ssh</kbd> directory exists and has
+the correct permissions, and appends your new public key to any existing
+authorized keys.</p>
+
+<p>If you have multiple keys, or use non-standard filenames, you may have to tell
+ssh what key to use. You can do this by adding a host directive in the ssh
+configuration file, <kbd>~/.ssh/config</kbd>:</p>
+
+<pre><code>Host www.example.com
+    IdentityFile ~/.ssh/id_rsa.example.com
+</code></pre>
+
+<ul>
+<li><a href="http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man5/ssh_config.5.html">ssh_config(5) manual page</a></li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/symbols.html
+++ b/doc/help/en/symbols.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>The symbol list</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>The symbol list</h1>
+
+<p>The symbol list shows language-specific symbols extracted from the document.
+You can navigate the symbol list by pressing the <kbd>&#x2318;Y</kbd> key.</p>
+
+<p>To jump to a symbol, select the symbol and press <kbd>enter</kbd>, <kbd>s</kbd>,
+<kbd>v</kbd> or <kbd>o</kbd> to open it in a tab, a split view, a vertical
+split, or replace the current document, respectively.</p>
+
+<p>Here is a list of all key mappings in the symbol list:</p>
+
+<ul>
+<li><kbd>h</kbd> &mdash; move up the tree hierarchy, closing documents</li>
+<li><kbd>l</kbd> &mdash; move down the tree hierarchy, opening documents</li>
+<li><kbd>j</kbd> &mdash; move down</li>
+<li><kbd>k</kbd> &mdash; move up</li>
+<li><kbd>&lt;ctrl-b&gt;</kbd> &mdash; scroll up one screen</li>
+<li><kbd>&lt;ctrl-f&gt;</kbd> &mdash; scroll down one screen</li>
+<li><kbd>&lt;ctrl-e&gt;</kbd> &mdash; scroll down one line</li>
+<li><kbd>&lt;ctrl-y&gt;</kbd> &mdash; scroll up one line</li>
+<li><kbd>G</kbd> &mdash; move to the last line (or a specific line with a count)</li>
+<li><kbd>gg</kbd> &mdash; move to the first line (or a specific line with a count)</li>
+<li><kbd>H</kbd> &mdash; move to top line ("<strong>H</strong>igh")</li>
+<li><kbd>M</kbd> &mdash; move to middle line</li>
+<li><kbd>L</kbd> &mdash; move to bottom line ("<strong>L</strong>ow")</li>
+<li><kbd>/</kbd> &mdash; search</li>
+<li><kbd>&lt;esc&gt;</kbd> &mdash; cancel and go back</li>
+<li><kbd>&lt;ctrl-c&gt;</kbd> &mdash; cancel and go back, or reset the search filter</li>
+<li><kbd>o</kbd> &mdash; open the selected symbol in the current view</li>
+<li><kbd>s</kbd> &mdash; open the selected symbol in a split view</li>
+<li><kbd>v</kbd> &mdash; open the selected symbol in a vertical split view</li>
+<li><kbd>t</kbd> &mdash; open the selected symbol in a tab</li>
+</ul>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/terminal.html
+++ b/doc/help/en/terminal.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Terminal usage</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Terminal usage</h1>
+
+<p><a name="terminalUsage"></a></p>
+
+<p>Vico includes a command line tool that can be used to launch vico from
+the shell.</p>
+
+<p>To use the tool from the command line, create a link from the
+application bundle to a directory in your PATH. If you have a
+<kbd>bin</kbd> directory in your home directory, create it as:</p>
+
+<pre><code>ln -s /Applications/Vico.app/Contents/MacOS/vicotool ~/bin/vico
+</code></pre>
+
+<p>If you want to install it for all users on the machine, create the link
+in a global directory (this requires administrator privileges):</p>
+
+<pre><code>sudo ln -s /Applications/Vico.app/Contents/MacOS/vicotool /usr/local/bin/vico
+</code></pre>
+
+<p>If Vico is not stored in your /Applications folder, adjust the command
+appropriately. Once the link is created, it will be kept up-to-date
+when Vico is updated.</p>
+
+<p>To open a file with Vico from the shell, simply type:</p>
+
+<pre><code>vico filename
+</code></pre>
+
+<p>You can open multiple files at once, also using globbing characters (eg,
+<kbd>vico *.py</kbd>). If you specify a directory, Vico will display a
+new window with the directory selected in the explorer sidebar.</p>
+
+<p>If you want to use Vico in your <kbd>$EDITOR</kbd> variable to edit
+commit messages, you need to use the <kbd>-w</kbd> switch. This makes
+Vico wait until the document is closed to return. The return code from
+vicotool is 0 if the document saved successfully before closing, and
+non-zero if it wasn't saved.</p>
+
+<p>To see a quick description of the command line usage, use the
+<kbd>-h</kbd> option:</p>
+
+<pre><code>$ vico -h
+syntax: vicotool [-hrw] [-e string] [-f file] [-p params] [file ...]
+options:
+    -h            show this help
+    -e string     evaluate the string as a Nu script
+    -f file       read file and evaluate as a Nu script
+    -p params     read script parameters as a JSON string
+    -p -          read script parameters as JSON from standard input
+    -r            enter runloop (don't exit script immediately)
+    -w            wait for document to close
+</code></pre>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>

--- a/doc/help/en/visual.html
+++ b/doc/help/en/visual.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Visual mode</title>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="main">
+
+<h1>Visual mode</h1>
+
+<p>When you select text in Vico, you enter visual mode. This is similar to normal
+mode in that keys act as commands. They do not replace the selected text (you
+must use the <a href="change.html">change</a> command for that).</p>
+
+<p>Commands that require a motion (<a href="operators.html">operators</a>) instead use the
+selected text directly.</p>
+
+<p>You can select text by dragging with the mouse, or with the <kbd>v</kbd> and
+<kbd>V</kbd> commands. The latter enters visual <strong>line mode</strong>, where only
+whole lines are selected. The selection is extended by moving around with the
+regular <a href="movement.html">movement</a> commands.</p>
+
+<p>You can toggle between visual line mode and character mode by pressing
+<kbd>v</kbd> while in line mode, or <kbd>V</kbd> while in visual character mode.</p>
+
+<p>Press <kbd>&#x238B;</kbd> (escape) to cancel the selection and go back to normal
+mode.</p>
+
+    </div>
+  </div>
+  <footer>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
This is everything that the Wayback Machine had from http://www.vicoapp.com/help/en/index.html except two missing pages: `open_line.html` and `tagstack.html`

CC #90 